### PR TITLE
Make SOURCERY_SETTING available at runtime

### DIFF
--- a/lib/CoreHackers/Sourcery.pm6
+++ b/lib/CoreHackers/Sourcery.pm6
@@ -1,5 +1,5 @@
 constant $GitHub-URL = 'https://github.com/rakudo/rakudo/blob/';
-constant $Setting = (
+my $Setting = (
     %*ENV<SOURCERY_SETTING>
         // $*EXECUTABLE.parent.parent.parent.child(&say.file)
 ).IO;


### PR DESCRIPTION
Currently, `SOURCERY_SETTING` is hardcode by value at compile time, so it leads to some weird behavior:

```
$ SOURCERY_SETTING=~/sources/rakudo/gen/moar/m-CORE.settingg perl6 ~/bin/test.p6
Failed to open file /Users/cuong/sources/rakudo/gen/moar/m-CORE.settingg: no such file or directory
```

Changing the value of `SOURCERY_SETTING` makes no effect:

```
SOURCERY_SETTING= perl6 ~/bin/test.p6
Failed to open file /Users/cuong/sources/rakudo/gen/moar/m-CORE.settingg: no such file or directory
```

In user perspective, it's better to dynamically change the value, so we don't need to re-compile every time we change the setting file location.
